### PR TITLE
Minor cleanups

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,10 @@ requirements:
 test:
   commands:
     - "file --help &> /dev/null"
-    - "test $CONDA_PREFIX/lib/libmagic.so"  # [linux]
-    - "test $CONDA_PREFIX/lib/libmagic.dylib"  # [osx]
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [linux]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - "test -r $CONDA_PREFIX/lib/libmagic.so"  # [linux]
+    - "test -r $CONDA_PREFIX/lib/libmagic.dylib"  # [osx]
+    - "conda inspect linkages -p $PREFIX $PKG_NAME"  # [linux]
+    - "conda inspect objects -p $PREFIX $PKG_NAME"  # [osx]
 
 about:
   home: http://www.darwinsys.com/file/


### PR DESCRIPTION
These are just some minor cleanups, which ensure that the "test" command checks for file-existence and read-access. Beforehand, the `test` command wasn't really verifying those qualities.